### PR TITLE
Version setting

### DIFF
--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -127,9 +127,6 @@ task UpdateNugetPackages RestoreNugetPackages, {
 
 # Synopsis: Update the version info in all AssemblyInfo.cs
 task UpdateVersionInfo GenerateVersionInformation, {
-	throw 'TODO: Either rely on GenerateVersionNumber or GenerateSemVerInformation - the latter is normal for libraries'
-    "Updating assembly information"
-
     # Ignore anything under the Testing/ folder
     @(Get-ChildItem "$RootDir" AssemblyInfo.cs -Recurse) | where { $_.FullName -notlike "$RootDir\Testing\*" } | ForEach {
         Update-AssemblyVersion $_.FullName `

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -26,41 +26,14 @@ task CreateFolders {
     New-Item $NugetPackageOutputDir -ItemType Directory -Force | Out-Null
 }
 
-# Retrieves the first Major.Minor line in $RootDir\RELEASENOTES.md as the $Version, appends
-# all subsequent lines in the file as $Content.
-function Get-ReleaseNotes {
-    $ReleaseNotesPath = "$RootDir\RELEASENOTES.md" | Resolve-Path
-    $Lines = [System.IO.File]::ReadAllLines($ReleaseNotesPath, [System.Text.Encoding]::UTF8)
-    $Result = @()
-    $Version = $Null
-    $Lines | ForEach-Object {
-        $Line = $_.Trim()
-        if (-not $Version) {
-            $Match = [regex]::Match($Line, '[0-9]+\.[0-9]+')
-            if ($Match.Success) {
-                $Version = $Match.Value
-            }
-        }
-        if ($Version) {
-            $Result += $Line
-        }
-    }
-    if (-not $Version) {
-        throw "Failed to parse release notes: $ReleaseNotesPath"
-    }
-    return @{
-        Content = $Result -join [System.Environment]::NewLine
-        Version = [version] $Version
-    }
-}
-
 # Synopsis: Retrieve two part semantic version information and release notes from $RootDir\RELEASENOTES.md
 # $script:AssemblyVersion = Major.0.0.0
 # $script:AssemblyFileVersion = Major.Minor.$VersionSuffix.0
 # $script:NugetPackageVersion = Major.Minor.$VersionSuffix or Major.Minor.$VersionSuffix-branch
 # $script:ReleaseNotes = read from RELEASENOTES.md
 function GenerateSemVerInformationFromReleaseNotesMd([int] $VersionSuffix) {
-    $Notes = Get-ReleaseNotes
+    $ReleaseNotesPath = "$RootDir\RELEASENOTES.md" | Resolve-Path
+    $Notes = Get-ReleaseNotes -ReleaseNotesPath $ReleaseNotesPath
     $script:SemanticVersion = [System.Version] "$($Notes.Version).$VersionSuffix"
     $script:ReleaseNotes = [string] $Notes.Content
 

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -75,8 +75,11 @@ task UpdateVersionInfo GenerateVersionNumber, {
 
 # Synopsis: Update the nuspec dependencies versions based on the versions of the nuget packages that are being used
 task UpdateNuspecVersionInfo {
-    # Get the list of packages.config we use from packages\repository.config
-    $packageConfigs = ([xml](Get-Content $RootDir\packages\repositories.config)).repositories.repository.path -replace '\.\.', "$RootDir"
+    # Find all the packages.config
+    $packageConfigs = Get-ChildItem "$RootDir" -Recurse -Filter "packages.config" `
+                      | ?{ $_.fullname -notmatch "\\(.build)|(packages)\\" } `
+                      | Resolve-Path
+
     # Update dependency verions in each of our .nuspec file based on what is in our packages.config
     Resolve-Path "$RootDir\Nuspec\*.nuspec" | Update-NuspecDependenciesVersions -PackagesConfigPaths $packageConfigs -verbose
 }

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -26,7 +26,7 @@ task CreateFolders {
     New-Item $NugetPackageOutputDir -ItemType Directory -Force | Out-Null
 }
 
-# Synopsis: Compute the value of the version info of SQL Source Control. (Save it in $script:Version for other tasks to use)
+# Synopsis: Compute the value of the version info. (Save it in $script:Version for other tasks to use)
 task GenerateVersionNumber {
   # For dev builds, version suffix is always 0
   $versionSuffix = 0

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -26,7 +26,6 @@ task CreateFolders {
     New-Item $NugetPackageOutputDir -ItemType Directory -Force | Out-Null
 }
 
-
 # Retrieves the first Major.Minor line in $RootDir\RELEASENOTES.md as the $Version, appends
 # all subsequent lines in the file as $Content.
 function Get-ReleaseNotes {
@@ -127,6 +126,8 @@ task UpdateNugetPackages RestoreNugetPackages, {
 
 # Synopsis: Update the version info in all AssemblyInfo.cs
 task UpdateVersionInfo GenerateVersionInformation, {
+    "Updating assembly information"
+
     # Ignore anything under the Testing/ folder
     @(Get-ChildItem "$RootDir" AssemblyInfo.cs -Recurse) | where { $_.FullName -notlike "$RootDir\Testing\*" } | ForEach {
         Update-AssemblyVersion $_.FullName `

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -137,7 +137,16 @@ task SignAssemblies -If ($Configuration -eq 'Release' -and $SigningServiceUrl -n
 
 # Synopsis: Execute our unit tests
 task UnitTests {
-    throw 'TODO: use Invoke-NUnitForAssembly from the RedGate.Build module'
+    throw 'TODO: use Invoke-NUnitForAssembly and Merge-CoverageReports from the RedGate.Build module'
+    # For example:
+    # Invoke-NUnitForAssembly `
+    #     -AssemblyPath "$RootDir\Build\Release\RedGate.Tests.dll" `
+    #     -NUnitVersion "2.6.4" `
+    #     -FrameworkVersion "net-4.0" `
+    #     -EnableCodeCoverage $true `
+    # 
+    # Merge-CoverageReports `
+    #     -SnapshotsDir "$RootDir\Build\Release"
 }
 
 # Synopsis: Build the nuget packages.

--- a/RELEASENODES.md
+++ b/RELEASENODES.md
@@ -1,0 +1,11 @@
+# Anything goes until the first line containing int.int for the Major.Minor version, all subsequent lines are release notes.
+
+# 0.1
+
+## Features
+
+- Example release notes
+
+## Fixes
+
+- RG-123: Behaviour is now better


### PR DESCRIPTION
SemVer information and release notes can come from RELEASENOTES.md as an alternative to version.txt
Example for UnitTests
Alternative packages.config location
