### PR TITLE
Minor tweaks

### DIFF
--- a/.build/_init.ps1
+++ b/.build/_init.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference = 'Stop'
 # of Invoke-WebRequest decent in Teamcity
 $ProgressPreference = 'SilentlyContinue'
 
-function script:RestoreBuildLevelPackages {
+function global:RestoreBuildLevelPackages {
     # Download paket.exe.
     # Use --prefer-nuget to get it from nuget.org first as it is quicker (compressed .nupkg)
     $paketVersion = "" # Set this to the value of a specific version of paket.exe to download if need be.

--- a/.build/_init.ps1
+++ b/.build/_init.ps1
@@ -61,7 +61,9 @@ function global:Build {
         [string] $NugetFeedUrl,
         # (Optional) Api Key to the nuget feed to be able to publish nuget packages.
         # Will be set by Teamcity.
-        [string] $NugetFeedApiKey
+        [string] $NugetFeedApiKey,
+        # (Optional) Signing service url used to sign dll/exe.
+        [string] $SigningServiceUrl
     )
 
     RestoreBuildLevelPackages
@@ -82,7 +84,8 @@ function global:Build {
         -BranchName $BranchName `
         -IsDefaultBranch $IsDefaultBranch `
         -NugetFeedUrl $NugetFeedUrl `
-        -NugetFeedApiKey $NugetFeedApiKey
+        -NugetFeedApiKey $NugetFeedApiKey `
+        -SigningServiceUrl $SigningServiceUrl `
     }
     finally
     {

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -232,8 +232,8 @@ task BuildNugetPackages Init, UpdateNuspecVersionInfo, {
 
 # Synopsis: Publish the nuget packages (Teamcity only)
 task PublishNugetPackages -If($PublishNugetPackages) {
-  assert ($NugetFeedUrl -ne $null) '$NugetFeedUrl is missing. Cannot publish nuget packages'
-  assert ($NugetFeedApiKey -ne $null) '$NugetFeedApiKey is missing. Cannot publish nuget packages'
+  assert ($NugetFeedUrl) '$NugetFeedUrl is missing. Cannot publish nuget packages'
+  assert ($NugetFeedApiKey) '$NugetFeedApiKey is missing. Cannot publish nuget packages'
 
   Get-ChildItem $NugetPackageOutputDir -Filter "*.nupkg" | ForEach {
     & $NugetExe push $_.FullName -Source $NugetFeedUrl -ApiKey $NugetFeedApiKey

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -150,10 +150,10 @@ task UpdateNuspecVersionInfo {
 }
 
 # Synopsis: A task that makes sure our initialization tasks have been run before we can do anything useful
-task Init CreateFolders, GenerateVersionInformation
+task Init CreateFolders, RestoreNugetPackages, GenerateVersionInformation
 
 # Synopsis: Compile the Visual Studio solution
-task Compile Init, RestoreNugetPackages, UpdateVersionInfo, {
+task Compile Init, UpdateVersionInfo, {
     try {
         exec {
             & "C:\Program Files (x86)\MSBuild\14.0\Bin\msbuild" `

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -44,8 +44,6 @@ function GenerateVersionInformationFromReleaseNotesMd([int] $VersionSuffix) {
     # Establish assembly version number
     $script:AssemblyVersion = $script:Version
     $script:AssemblyFileVersion = $script:Version
-
-    $script:NugetPackageVersion = New-NugetPackageVersion -Version $script:Version -BranchName $BranchName -IsDefaultBranch $IsDefaultBranch
     
     TeamCity-PublishArtifact "$ReleaseNotesPath"
 }

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -4,7 +4,8 @@ param(
     [string] $BranchName = 'dev',
     [bool] $IsDefaultBranch = $false,
     [string] $NugetFeedUrl,
-    [string] $NugetFeedApiKey
+    [string] $NugetFeedApiKey,
+    [string] $SigningServiceUrl
 )
 
 $RootDir = "$PsScriptRoot\.." | Resolve-Path
@@ -45,6 +46,8 @@ function GenerateVersionInformationFromReleaseNotesMd([int] $VersionSuffix) {
     $script:AssemblyFileVersion = $script:Version
 
     $script:NugetPackageVersion = New-NugetPackageVersion -Version $script:Version -BranchName $BranchName -IsDefaultBranch $IsDefaultBranch
+    
+    TeamCity-PublishArtifact "$ReleaseNotesPath"
 }
 
 # Synopsis: Retrieve two part semantic version information and release notes from $RootDir\RELEASENOTES.md
@@ -61,6 +64,8 @@ function GenerateSemVerInformationFromReleaseNotesMd([int] $VersionSuffix) {
     # Establish assembly version number
     $script:AssemblyVersion = [version] "$($script:Version.Major).0.0.0"
     $script:AssemblyFileVersion = [version] "$script:Version.0"
+    
+    TeamCity-PublishArtifact "$ReleaseNotesPath"
 }
 
 # Synopsis: Retrieve three part version information from .build\version.txt
@@ -183,7 +188,7 @@ task SmartAssembly -If ($Configuration -eq 'Release') {
 }
 
 # Synopsis: Sign all the RedGate assemblies (Release and Obfuscated)
-task SignAssemblies -If ($Configuration -eq 'Release' -and $SigningServiceUrl -ne $null) {
+task SignAssemblies -If ($Configuration -eq 'Release' -and $SigningServiceUrl) {
     throw 'TODO: use Invoke-SigningService from the RedGate.Build module'
     # For example:
     # Get-Item -Path "$RootDir\Build\Release\*.*" `

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -145,10 +145,10 @@ task UpdateNuspecVersionInfo {
 }
 
 # Synopsis: A task that makes sure our initialization tasks have been run before we can do anything useful
-task Init CreateFolders, RestoreNugetPackages, GenerateVersionInformation
+task Init CreateFolders, GenerateVersionInformation
 
 # Synopsis: Compile the Visual Studio solution
-task Compile Init, UpdateVersionInfo, {
+task Compile Init, RestoreNugetPackages, UpdateVersionInfo, {
     try {
         exec {
             & "C:\Program Files (x86)\MSBuild\14.0\Bin\msbuild" `

--- a/.build/build.ps1
+++ b/.build/build.ps1
@@ -213,16 +213,20 @@ task UnitTests {
 task BuildNugetPackages Init, UpdateNuspecVersionInfo, {
     New-Item $NugetPackageOutputDir -ItemType Directory -Force | Out-Null
 
+    $escaped=$ReleaseNotes.Replace('"','\"')
+    $properties = "releaseNotes=$escaped"
+    
     "$RootDir\Nuspec\*.nuspec" | Resolve-Path | ForEach {
         exec {
             & $NugetExe pack $_ `
-                -version $NugetPackageVersion `
+                -Version $NugetPackageVersion `
                 -OutputDirectory $NugetPackageOutputDir `
                 -BasePath $RootDir `
-                -Properties "releaseNotes=$ReleaseNotes" `
+                -Properties $properties `
                 -NoPackageAnalysis
         }
     }
+    
     TeamCity-PublishArtifact "$NugetPackageOutputDir\*.nupkg => NugetPackages"
 }
 

--- a/.build/installer.tasks.ps1
+++ b/.build/installer.tasks.ps1
@@ -39,7 +39,8 @@ function Setup-InstallerPrerequisites {
         -WixVersion '2' `
         -NugetPackagesDirectory "$RootDir\packages"
 
-    Copy-Item "$RootDir\Install\Wix2\*" "$BinDirectory\Release\Wix2" -Recurse -Force -Verbose
+    New-Item "$BinDirectory\Release\Wix2\" -ItemType Directory -Force | Out-Null
+    Copy-Item "$RootDir\Install\Wix2\*" "$BinDirectory\Release\Wix2\" -Recurse -Force -Verbose
 }
 
 function New-Installer($ProductName) {
@@ -83,11 +84,14 @@ function New-Installer($ProductName) {
         -PathToMiniInstallers "$BinDirectory\Installer"
 }
 
-task Installer Init, SignAssemblies, {
+task Installer Init, {
+    assert ($SigningServiceUrl) '$SigningServiceUrl is missing. Cannot create installers'
+  
+    New-Item "$RootDir\Build\Installers\Release\" -ItemType Directory -Force | Out-Null
     # Copy Release directory into a working directory for the installers
-    Copy-Item "$RootDir\Build\Release\*" "$RootDir\Build\Installers\Release" -Recurse -Force
+    Copy-Item "$RootDir\Build\Release\*" "$RootDir\Build\Installers\Release\" -Recurse -Force
     # Overwrite with any obfuscated files
-    Copy-Item "$RootDir\Build\Obfuscated\*" "$RootDir\Build\Installers\Release" -Recurse -Force
+    Copy-Item "$RootDir\Build\Obfuscated\*" "$RootDir\Build\Installers\Release\" -Recurse -Force
 
     Setup-InstallerPrerequisites
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ yo
   * We can choose to commit this file or not.
     * If it is committed, paket dependencies will not change when calling `paket install`. What is defined in `paket.lock` is what gets installed.
     * If it is not committed, each call to `paket install` may download new versions based on the versions set in `paket.dependencies`
-* [.build\\version.txt](.build/version.txt)
+* [.build\\version.txt](.build/version.txt) (also see [RELEASENOTES.md](#RELEASENOTES.md))
   * Contain the version number.
     * Could be *'major.minor'* (build script could add a 3rd dynamic number if need be)
     * Could be *'major.minor.patch'* (build script could add a 4th dynamic number if need be)
@@ -76,3 +76,9 @@ yo
   * nuget.org
   * our own internal feed
   * our own internal teamcity feed
+
+### RELEASENOTES.md
+* [RELEASENOTES.md](RELEASENOTES.md)
+  * Contains the full parseable release notes which can be used instead of version.txt to supply the version number of the build in addition to providing release notes for nuget package and more.
+    * Could be *'major.minor'* (build script could add a 3rd (and 4th) dynamic number if need be)
+    * Could be *'major.minor.patch'* (build script could add a 4th dynamic number if need be)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ yo
   * We can choose to commit this file or not.
     * If it is committed, paket dependencies will not change when calling `paket install`. What is defined in `paket.lock` is what gets installed.
     * If it is not committed, each call to `paket install` may download new versions based on the versions set in `paket.dependencies`
-* [.build\\version.txt](.build/version.txt) (also see [RELEASENOTES.md](#RELEASENOTES.md))
+* [.build\\version.txt](.build/version.txt) (also see [RELEASENOTES.md](#releasenotesmd))
   * Contain the version number.
     * Could be *'major.minor'* (build script could add a 3rd dynamic number if need be)
     * Could be *'major.minor.patch'* (build script could add a 4th dynamic number if need be)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,4 @@
-# Anything goes until the first line containing int.int for the Major.Minor version, all subsequent lines are release notes.
-
+# Anything goes until the first line containing int.int for the Major.Minor version or int.int.int Major.Minor.Build, all subsequent lines are release notes - see [Get-ReleaseNotes.ps1](https://github.com/red-gate/RedGate.Build/blob/master/Public/Get-ReleaseNotes.ps1)
 # 0.1
 
 ## Features


### PR DESCRIPTION
SQL Dependency Tracker building has thrown up a few more things
- RELEASENOTES.md returning a three part version for products
- global: change to avoid `. .\.build\_init.ps1`
- Issue if RELEASENOTES contains " in nuget pack stage
- Empty string for nuget push wasn't failing `assert()`
- Do unit tests earlier than slow {sa} and signing
- Augment README.md for RELEASESNOTES.md
- SigningServiceUrl comes in like $Nuget*
- RELEASENOTES.md is useful in artefacts for a separate installer build
- Create directories before using as Copy-Item targets or "strange things" happen
